### PR TITLE
Add basic security best practices to Minikube lab6 YAML

### DIFF
--- a/lab6-accessing-interacting-minikube/deny-all-policy.yaml
+++ b/lab6-accessing-interacting-minikube/deny-all-policy.yaml
@@ -4,7 +4,11 @@ metadata:
   name: deny-all
   namespace: default
 spec:
+  # Selects all pods in the namespace
   podSelector: {}
+
+  # Denies all incoming and outgoing traffic
   policyTypes:
   - Ingress
   - Egress
+

--- a/lab6-accessing-interacting-minikube/test-pod.yaml
+++ b/lab6-accessing-interacting-minikube/test-pod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: test-container
-    image: busybox:latest
+    image: busybox:1.36
     command: ['sh', '-c', 'echo "Hello from Kubernetes Pod!" && sleep 3600']
     resources:
       requests:
@@ -17,3 +17,15 @@ spec:
       limits:
         memory: "128Mi"
         cpu: "500m"
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+    livenessProbe:
+      exec:
+        command:
+          - sh
+          - -c
+          - echo healthy
+      initialDelaySeconds: 10
+      periodSeconds: 30
+


### PR DESCRIPTION
This PR improves the Kubernetes manifests used in the Minikube security lab:

- Replaced `latest` image tag with a fixed version.
- Added container `securityContext` to avoid running as root.
- Added a simple liveness probe to demonstrate health checks.
- Added inline documentation to the network policy.

These changes make the lab more realistic and align with common Kubernetes security practices without increasing complexity.