### PR TITLE
Harden test deployment with security context and probes in the lab8

### DIFF
--- a/lab8-k8s-security/deployments/test-deployment.yaml
+++ b/lab8-k8s-security/deployments/test-deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: security-lab
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
   selector:
     matchLabels:
       app: test-app
@@ -15,7 +20,25 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.20
+        image: nginx:1.25
+        ports:
+        - containerPort: 80
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 101
+          readOnlyRootFilesystem: true
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
         resources:
           requests:
             memory: "64Mi"
@@ -23,3 +46,4 @@ spec:
           limits:
             memory: "128Mi"
             cpu: "500m"
+


### PR DESCRIPTION
This PR improves `deployments/test-deployment.yaml `to better reflect real-world Kubernetes security and reliability practices.

**Changes**

- Updated nginx image to a newer stable version
- Added non-root security context
- Enabled read-only root filesystem
- Added readiness and liveness probes
- Added rolling update strategy