### PR TITLE
Add application metadata and feature flags to ConfigMap in the lab13

### DIFF
--- a/lab13-configmaps-secrets-app/app.properties
+++ b/lab13-configmaps-secrets-app/app.properties
@@ -1,6 +1,15 @@
+app.name=configmap-demo-app
+app.version=1.0.0
+
 database.host=mysql-service
 database.port=3306
+
 app.environment=production
 log.level=info
+
 cache.enabled=true
 cache.ttl=300
+
+feature.beta=false
+metrics.enabled=true
+


### PR DESCRIPTION
This PR improves the ConfigMap by adding standard application-level configuration.

Changes

- Added `app.name`
- Added `app.version`
- Added feature flag support
- Added metrics toggle

**Why this matters**

In real Kubernetes environments:

- ConfigMaps are used for both infrastructure and app behavior
- Feature flags enable safe releases
- Metadata helps debugging and observability
- Metrics flags support monitoring systems

These changes make the lab closer to production-grade configuration management.

**Files updated**
`app.properties`