### PR TITLE
Enforce HTTPS and add HSTS to advanced ingress in the lab14

### DIFF
--- a/lab14-ingress-routing/ingress-advanced.yaml
+++ b/lab14-ingress-routing/ingress-advanced.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "31536000"
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
This PR improves security for the advanced Ingress configuration.

**Changes**

- Enabled forced SSL redirection
- Added HSTS support
- Configured long HSTS max-age

**Why this matters**

In real environments:

- All traffic should be HTTPS
- Browsers should remember HTTPS via HSTS
- This prevents downgrade and MITM attacks

These changes make the Ingress closer to real production security standards.

**Files updated**
`ingress-advanced.yaml`