### PR TITLE
Make load generator rate configurable via environment variable in the lab15

### DIFF
--- a/lab15-k8s-autoscaling/load-generator-deployment.yaml
+++ b/lab15-k8s-autoscaling/load-generator-deployment.yaml
@@ -15,9 +15,19 @@ spec:
       containers:
       - name: load-generator
         image: busybox
+        env:
+        - name: REQUEST_INTERVAL
+          value: "0.1"
         command: ["/bin/sh"]
-        args: ["-c", "while true; do wget -q -O- http://php-apache; sleep 0.1; done"]
+        args:
+        - -c
+        - |
+          while true; do
+            wget -q -O- http://php-apache
+            sleep $REQUEST_INTERVAL
+          done
         resources:
           requests:
             cpu: 100m
             memory: 64Mi
+


### PR DESCRIPTION
This PR improves the `load-generator` deployment by introducing a configurable request interval.

**Changes**:

- Added `REQUEST_INTERVAL` environment variable.
- Replaced hardcoded `sleep 0.1 `with dynamic value.
- Keeps default behavior identical.

This makes autoscaling experiments more realistic and reusable.