### PR TITLE
Make Deployment CI/CD Ready with Dynamic Image Tag and Resource Limits

### DIFF
--- a/lab16-k8s-cicd/k8s-manifests/deployment.yaml
+++ b/lab16-k8s-cicd/k8s-manifests/deployment.yaml
@@ -16,17 +16,25 @@ spec:
     spec:
       containers:
       - name: cicd-app
-        image: cicd-app:v1.0.0
+        image: cicd-app:${IMAGE_TAG}
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
         env:
         - name: APP_VERSION
-          value: "1.0.0"
+          value: "${IMAGE_TAG}"
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "300m"
+            memory: "256Mi"
         livenessProbe:
           httpGet:
             path: /health
             port: 3000
-          initialDelaySeconds: 30
+          initialDelaySeconds: 20
           periodSeconds: 10
         readinessProbe:
           httpGet:
@@ -34,3 +42,4 @@ spec:
             port: 3000
           initialDelaySeconds: 5
           periodSeconds: 5
+


### PR DESCRIPTION
This PR improves the Kubernetes deployment by making it suitable for real CI/CD pipelines.

**Changes**

- Replaced hardcoded image tag with `${IMAGE_TAG}`.
- Synced `APP_VERSION` with image version.
- Added CPU and memory requests/limits.
- Added `imagePullPolicy` for better image handling.

**Why**

These changes:

- Enable automated versioning from CI pipelines.
- Prevent resource abuse in the cluster.
- Reflect how real production deployments are managed.