### PR TITLE
Harden sample-app deployment for GitOps with ArgoCD in the lab20

### DIFF
--- a/lab20-gitops-argocd/apps/sample-app/deployment.yaml
+++ b/lab20-gitops-argocd/apps/sample-app/deployment.yaml
@@ -2,8 +2,16 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sample-app
+  labels:
+    app: sample-app
+    managed-by: argocd
 spec:
   replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
   selector:
     matchLabels:
       app: sample-app
@@ -15,18 +23,31 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.22
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "64Mi"
+          limits:
+            cpu: "300m"
+            memory: "128Mi"
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 101
         livenessProbe:
           httpGet:
             path: /
             port: 80
           initialDelaySeconds: 20
+          periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /
             port: 80
           initialDelaySeconds: 5
+          periodSeconds: 5
         volumeMounts:
         - name: web
           mountPath: /usr/share/nginx/html/index.html
@@ -35,3 +56,4 @@ spec:
       - name: web
         configMap:
           name: web-content
+


### PR DESCRIPTION
This PR improves the sample-app Deployment to better reflect
real-world GitOps practices.

**Changes:**
- Added rolling update strategy
- Added resource requests and limits
- Added security context (non-root)
- Added ArgoCD management labels
- Improved probe timing

This makes the GitOps lab production-ready and more realistic.